### PR TITLE
Changed get_consumption_site to get_consumption_stats in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ Examples
       u'success': True}
     
     
-    >> api.get_consumption_site(inst_id=4470) 
+    >> api.get_consumption_stats(inst_id=4470) 
     
     >>{u'records': {u'Bc': [[1473681210000, 0.018203735351562],
        [1473692010000, 0.018211364746094],


### PR DESCRIPTION
The function get_consumption_site does not exist and is changed to
get_consumption_stats in the example in README.rst.

Signed-off-by: Ole Saether <osaether@gmail.com>